### PR TITLE
Cast pr col as type bool to suppress FutureWarning

### DIFF
--- a/get-data.py
+++ b/get-data.py
@@ -162,6 +162,7 @@ columns = [
     "repository",
 ]
 df = pd.DataFrame(columns=columns)
+df["pull_request"] = df["pull_request"].astype(bool)
 
 queries = {
     f"is:issue is:open assignee:{username}": "assigned",


### PR DESCRIPTION
Received warning:
> FutureWarning: In a future version, object-dtype columns with all-bool values will not be included in reductions with bool_only=True. Explicitly cast to bool dtype instead.